### PR TITLE
fix(index): example code snippet

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -49,7 +49,7 @@ const textContent = {
       }
     },
     proofFormat: 'jwt',
-    save: true
+    save: false
   })
 
   `,


### PR DESCRIPTION
this example code would cause errors, because there is no `IDataStore` plugin in the agent setup.