### PR TITLE
Adjust docs according to 3.0.0 Release Notes

### DIFF
--- a/docs/react_native_tutorials/react_native_setup_identifiers.md
+++ b/docs/react_native_tutorials/react_native_setup_identifiers.md
@@ -6,7 +6,7 @@ sidebar_label: Setup & Identifiers
 
 This guide will walk you through setting up Veramo on React Native. You should have a good understanding of React Native
 and have your environment set up correctly to build iOS and Android apps. Check out
-the [React Native](https://reactnative.dev/docs/environment-setup) docs to learn more. Node v12 or later is required to
+the [React Native](https://reactnative.dev/docs/environment-setup) docs to learn more. Node v14 or later is required to
 run Veramo.
 
 ## Introduction

--- a/docs/veramo_agent/cli_tool.md
+++ b/docs/veramo_agent/cli_tool.md
@@ -4,7 +4,7 @@ title: CLI Tool
 sidebar_label: CLI Tool
 ---
 
-:::important Ensure you have Node v12 or later installed. The CLI tool is currently only supported on MACOS and Linux
+:::important Ensure you have Node v14 or later installed. The CLI tool is currently only supported on MACOS and Linux
 systems. Windows support is coming soon.
 :::
 
@@ -26,7 +26,7 @@ To check the CLI has installed, run:
 veramo -v
 
 # Output
-2.x.x
+3.x.x
 ```
 
 ### Methods


### PR DESCRIPTION
- Update `node_setup_identifiers.md` with the instructions from the [Release Notes 3.0](https://veramo.io/blog/#ok-so-how-does-it-affect-me)
- Change the required Node version due to the following error: `error did-jwt-vc@2.1.7: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.16.2"`