### PR TITLE
fix: using repository_dispatch instead of workflow_dispatch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,7 @@
 name: Trigger veramo-website build
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - 'italo/fix-docs'
+  repository_dispatch:
+    types: [deploy_website]
 jobs:
   docs:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
 Using `repository_dispatch ` instead `workflow_dispatch` to avoid doubts about the token permissions when dispatching to the repo.