### PR TITLE
docs: update community links in readme

### DIFF
--- a/docs/api/core.agent._constructor_.md
+++ b/docs/api/core.agent._constructor_.md
@@ -18,6 +18,6 @@ constructor(options?: IAgentOptions);
 
 ## Parameters
 
-| Parameter | Type                                     | Description                             |
-| --------- | ---------------------------------------- | --------------------------------------- |
-| options   | [IAgentOptions](./core.iagentoptions.md) | <i>(Optional)</i> Configuration options |
+| Parameter | Type                                     | Description           |
+| --------- | ---------------------------------------- | --------------------- |
+| options   | [IAgentOptions](./core.iagentoptions.md) | Configuration options |

--- a/docs/api/core.ipluginmethodmap.md
+++ b/docs/api/core.ipluginmethodmap.md
@@ -16,4 +16,4 @@ Plugin method map interface
 export interface IPluginMethodMap extends Record<string, IPluginMethod>
 ```
 
-<b>Extends:</b> Record&lt;string, [IPluginMethod](./core.ipluginmethod.md)
+<b>Extends:</b> Record&lt;string, [IPluginMethod](./core.ipluginmethod.md)&gt;

--- a/docs/api/data-store.credential_2.raw.md
+++ b/docs/api/data-store.credential_2.raw.md
@@ -11,5 +11,7 @@ hide_title: true
 <b>Signature:</b>
 
 ```typescript
+get raw(): VerifiableCredential;
+
 set raw(raw: VerifiableCredential);
 ```

--- a/docs/api/data-store.keystore.list.md
+++ b/docs/api/data-store.keystore.list.md
@@ -16,9 +16,9 @@ list(args?: {}): Promise<ManagedKeyInfo[]>;
 
 ## Parameters
 
-| Parameter | Type | Description       |
-| --------- | ---- | ----------------- |
-| args      | {}   | <i>(Optional)</i> |
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| args      | {}   |             |
 
 <b>Returns:</b>
 

--- a/docs/api/data-store.presentation.raw.md
+++ b/docs/api/data-store.presentation.raw.md
@@ -11,5 +11,7 @@ hide_title: true
 <b>Signature:</b>
 
 ```typescript
+get raw(): VerifiablePresentation;
+
 set raw(raw: VerifiablePresentation);
 ```

--- a/docs/api/data-store.privatekeystore._constructor_.md
+++ b/docs/api/data-store.privatekeystore._constructor_.md
@@ -18,7 +18,7 @@ constructor(dbConnection: Promise<Connection>, secretBox?: AbstractSecretBox | u
 
 ## Parameters
 
-| Parameter    | Type                                                                     | Description       |
-| ------------ | ------------------------------------------------------------------------ | ----------------- |
-| dbConnection | Promise&lt;Connection&gt;                                                |                   |
-| secretBox    | [AbstractSecretBox](./key-manager.abstractsecretbox.md) &#124; undefined | <i>(Optional)</i> |
+| Parameter    | Type                                                                     | Description |
+| ------------ | ------------------------------------------------------------------------ | ----------- |
+| dbConnection | Promise&lt;Connection&gt;                                                |             |
+| secretBox    | [AbstractSecretBox](./key-manager.abstractsecretbox.md) &#124; undefined |             |

--- a/docs/api/did-comm.abstractdidcommtransport._constructor_.md
+++ b/docs/api/did-comm.abstractdidcommtransport._constructor_.md
@@ -20,6 +20,6 @@ constructor(id?: string);
 
 ## Parameters
 
-| Parameter | Type   | Description                                                                                             |
-| --------- | ------ | ------------------------------------------------------------------------------------------------------- |
-| id        | string | <i>(Optional)</i> An optional identifier for this [IDIDCommTransport](./did-comm.ididcommtransport.md). |
+| Parameter | Type   | Description                                                                           |
+| --------- | ------ | ------------------------------------------------------------------------------------- |
+| id        | string | An optional identifier for this [IDIDCommTransport](./did-comm.ididcommtransport.md). |

--- a/docs/api/did-comm.didcomm._constructor_.md
+++ b/docs/api/did-comm.didcomm._constructor_.md
@@ -20,6 +20,6 @@ constructor(transports?: IDIDCommTransport[]);
 
 ## Parameters
 
-| Parameter  | Type                                                     | Description                                                                               |
-| ---------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| transports | [IDIDCommTransport](./did-comm.ididcommtransport.md)\[\] | <i>(Optional)</i> A list of [IDIDCommTransport](./did-comm.ididcommtransport.md) objects. |
+| Parameter  | Type                                                     | Description                                                             |
+| ---------- | -------------------------------------------------------- | ----------------------------------------------------------------------- |
+| transports | [IDIDCommTransport](./did-comm.ididcommtransport.md)\[\] | A list of [IDIDCommTransport](./did-comm.ididcommtransport.md) objects. |

--- a/docs/api/did-comm.didcommhttptransport._constructor_.md
+++ b/docs/api/did-comm.didcommhttptransport._constructor_.md
@@ -20,6 +20,6 @@ constructor(httpMethod?: 'post' | 'get');
 
 ## Parameters
 
-| Parameter  | Type                | Description                                                                    |
-| ---------- | ------------------- | ------------------------------------------------------------------------------ |
-| httpMethod | 'post' &#124; 'get' | <i>(Optional)</i> Default HTTP method if not specified in the service section. |
+| Parameter  | Type                | Description                                                  |
+| ---------- | ------------------- | ------------------------------------------------------------ |
+| httpMethod | 'post' &#124; 'get' | Default HTTP method if not specified in the service section. |

--- a/docs/api/message-handler.message._constructor_.md
+++ b/docs/api/message-handler.message._constructor_.md
@@ -21,6 +21,6 @@ constructor(data?: {
 
 ## Parameters
 
-| Parameter | Type                                                              | Description       |
-| --------- | ----------------------------------------------------------------- | ----------------- |
-| data      | { raw: string; metaData?: [IMetaData](./core.imetadata.md)\[\]; } | <i>(Optional)</i> |
+| Parameter | Type                                                              | Description |
+| --------- | ----------------------------------------------------------------- | ----------- |
+| data      | { raw: string; metaData?: [IMetaData](./core.imetadata.md)\[\]; } |             |

--- a/docs/react_native_tutorials/react_native_setup_identifiers.md
+++ b/docs/react_native_tutorials/react_native_setup_identifiers.md
@@ -1,5 +1,5 @@
 ---
-id: react_native_setup_identifers
+id: react_native_setup_identifiers
 title: React Native Setup & Identifiers
 sidebar_label: Setup & Identifiers
 ---

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,7 +92,7 @@ module.exports = {
             },
             {
               label: 'React Native',
-              to: 'docs/react_native_tutorials/react_native_setup_identifers',
+              to: 'docs/react_native_tutorials/react_native_setup_identifiers',
             },
           ],
         },
@@ -117,16 +117,16 @@ module.exports = {
           title: 'Community',
           items: [
             {
-              label: 'GitHub',
-              href: 'https://github.com/uport-project/veramo',
-            },
-            {
-              label: 'Discussions',
-              href: 'https://github.com/uport-project/veramo/discussions',
-            },
-            {
               label: 'Discord',
               href: 'https://discord.gg/FRRBdjemHV',
+            },
+            {
+              label: 'Twitter',
+              href: 'https://twitter.com/veramolabs',
+            },
+            {
+              label: 'GitHub',
+              href: 'https://github.com/uport-project/veramo',
             },
           ],
         },
@@ -141,12 +141,12 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/uport-project/veramo-website/blob/master/',
+          editUrl: 'https://github.com/uport-project/veramo-website/edit/main/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
-          editUrl: 'https://github.com/uport-project/veramo-website/edit/master/website/blog/',
+          editUrl: 'https://github.com/uport-project/veramo-website/edit/main/',
           feedOptions: {
             type: 'all',
             copyright: `Copyright © ${new Date().getFullYear()} Veramo`,

--- a/sidebars.js
+++ b/sidebars.js
@@ -48,7 +48,7 @@ module.exports = {
     {
       type: 'category',
       label: 'React Native Tutorials',
-      items: ['react_native_tutorials/react_native_setup_identifers'],
+      items: ['react_native_tutorials/react_native_setup_identifiers'],
     },
     {
       type: 'category',


### PR DESCRIPTION
The actual changes are in [`docusaurus.config.js`](https://github.com/uport-project/veramo-website/pull/114/files#diff-a038096cbdea434999e1dce5ab497212f1fe18204dde1a027ce3bdd663261a2a):
 * add twitter link and rearrange community links
 * rename the link to the react-native setup
 * fix "Edit this page" broken links


All else is coming from the docs getting regenerated during the local build.