### PR TITLE
fix: broken link to API reference

### DIFF
--- a/docs/veramo_agent/cli_tool.md
+++ b/docs/veramo_agent/cli_tool.md
@@ -26,7 +26,7 @@ To check the CLI has installed, run:
 veramo -v
 
 # Output
-3.x.x
+4.x.x
 ```
 
 ### Methods

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,7 +45,7 @@ module.exports = {
           position: 'right',
         },
         {
-          to: 'docs/api/index',
+          to: 'docs/api',
           activeBasePath: 'docs',
           label: 'API',
           position: 'right',

--- a/src/pages/developer_tools.js
+++ b/src/pages/developer_tools.js
@@ -75,7 +75,7 @@ function Tools() {
   return (
     <section>
       <div className={styles.container}>
-        <div className={clsx(styles.infoSection, styles.infoSectionPadding)}>
+        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionCenter)}>
           <h1 style={{ fontSize: '3rem' }}>Developer Tools</h1>
           <p className={'promoText'} style={{ fontSize: 18 }}>
             The core developer tools are specific libraries that use Veramo and make using Veramo easier.
@@ -95,7 +95,7 @@ function Kits() {
   return (
     <section className={'oddRow'}>
       <div className={styles.container}>
-        <div className={clsx(styles.infoSection, styles.infoSectionPadding)}>
+        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionCenter)}>
           <h1 style={{ fontSize: '3rem' }}>Developer Toolkits</h1>
           <p className={'promoText'} style={{ fontSize: 18 }}>
             These kits consist of recommended plugins, agent configurations, architecture and step-by-step

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -89,7 +89,7 @@ function VerifiableData() {
   return (
     <section>
       <div className={styles.container}>
-        <div className={clsx(styles.infoSection, styles.infoSectionPadding)}>
+        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionCenter)}>
           <h1 style={{ fontSize: '3rem' }}>{textContent.verifiableDataTitle}</h1>
           <p className={styles.promoText} style={{ fontSize: 18 }}>
             {textContent.verifiableDataContent}
@@ -109,7 +109,7 @@ function CleanAPI() {
   return (
     <section className={'oddRow'}>
       <div className={styles.container}>
-        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionLifted)}>
+        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionLifted, styles.infoSectionCenter)}>
           <h1 style={{ fontSize: '3rem' }}>{textContent.cleanApi}</h1>
           <p className={'promoText'} style={{ fontSize: 18 }}>
             {textContent.cleanApiContent}
@@ -140,7 +140,7 @@ function AwesomeCli() {
   return (
     <section className={'oddRow'}>
       <div className={styles.container}>
-        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionLifted)}>
+        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionLifted, styles.infoSectionCenter)}>
           <h1 style={{ fontSize: '3rem' }}>{textContent.awesomeCLITitle}</h1>
           <p className={'promoText'} style={{ fontSize: 18 }}>
             {textContent.awesomeCLI}
@@ -186,7 +186,7 @@ function Plugins() {
   return (
     <section>
       <div className={styles.container}>
-        <div className={clsx(styles.infoSection, styles.infoSectionPadding)}>
+        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionCenter)}>
           <h1 style={{ fontSize: '3rem' }}>Plugins</h1>
           <p className={'promoText'} style={{ fontSize: 18 }}>
             {textContent.plugins}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -109,7 +109,14 @@ function CleanAPI() {
   return (
     <section className={'oddRow'}>
       <div className={styles.container}>
-        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionLifted, styles.infoSectionCenter)}>
+        <div
+          className={clsx(
+            styles.infoSection,
+            styles.infoSectionPadding,
+            styles.infoSectionLifted,
+            styles.infoSectionCenter,
+          )}
+        >
           <h1 style={{ fontSize: '3rem' }}>{textContent.cleanApi}</h1>
           <p className={'promoText'} style={{ fontSize: 18 }}>
             {textContent.cleanApiContent}
@@ -140,11 +147,21 @@ function AwesomeCli() {
   return (
     <section className={'oddRow'}>
       <div className={styles.container}>
-        <div className={clsx(styles.infoSection, styles.infoSectionPadding, styles.infoSectionLifted, styles.infoSectionCenter)}>
+        <div
+          className={clsx(
+            styles.infoSection,
+            styles.infoSectionPadding,
+            styles.infoSectionLifted,
+            styles.infoSectionCenter,
+          )}
+        >
           <h1 style={{ fontSize: '3rem' }}>{textContent.awesomeCLITitle}</h1>
           <p className={'promoText'} style={{ fontSize: 18 }}>
             {textContent.awesomeCLI}
           </p>
+          <CodeBlock className={styles.npmInstall} language={'bash'}>
+            npm i @veramo/cli -g
+          </CodeBlock>
         </div>
       </div>
     </section>
@@ -248,15 +265,6 @@ function Home() {
             >
               Get Started
             </Link>
-            <Link
-              className={clsx('button button--secondary button--no-border', styles.learnMore)}
-              to={useBaseUrl('docs/basics/introduction')}
-            >
-              Learn more
-            </Link>
-            <div className={styles.npmInstall}>
-              <CodeBlock language={'bash'}>npm i @veramo/cli -g</CodeBlock>
-            </div>
           </div>
         </div>
       </header>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -50,6 +50,9 @@
 
 .npmInstall {
   display: none;
+  text-align: left;
+  width: fit-content;
+  padding: 0 10px;
 }
 
 .infoSection {

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -53,8 +53,11 @@
 }
 
 .infoSection {
-  text-align: center;
   width: 100%;
+}
+
+.infoSectionCenter {
+  text-align: center;
 }
 
 .infoSectionPadding {


### PR DESCRIPTION
Fixes a broken link that was reported on discord (https://discord.com/channels/878293684620234752/890207307433136178/1071560622719914095)

This also fixes an alignment issue with code blocks, deduplicates the buttons (get started / learn more) that lead to the same place and moves the npmInstall block in the Awesome CLI section